### PR TITLE
 Update array syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan,
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     dplyr,
     tidyr,
@@ -48,8 +48,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements:
 	GNU make
 	C++17

--- a/inst/stan/Hybrid.stan
+++ b/inst/stan/Hybrid.stan
@@ -2,37 +2,37 @@
 data {
   int NE; //num entries in data frame.
   int NF; //num features
-  int MT[NE]; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
+  array[NE] int MT; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
   int nMT; // number of different mutation types
-  int FE[NE]; //  feature  for each entry
-  int R[NE]; //Replicate ID
+  array[NE] int FE; //  feature  for each entry
+  array[NE] int R; //Replicate ID
   int nrep;
-  real tl[nMT];
-  real logit_fn_rep[NE]; //Replicate fn estimate
-  real fn_se[NE] ; //Standard error of replicate fn estimate
-  real Avg_Reads[NF, nMT]; // Average read counts in transcript i and sample j (avg. across replicates)
+  array[nMT] real tl;
+  array[NE] real logit_fn_rep; //Replicate fn estimate
+  array[NE] real fn_se ; //Standard error of replicate fn estimate
+  array[NF, nMT] real Avg_Reads; // Average read counts in transcript i and sample j (avg. across replicates)
   int<lower = 0, upper = 1> Chase;
 }
 
 parameters {
-  vector[nMT] alpha[NF];
+  array[NF] vector[nMT] alpha;
   vector[nMT] mu_fn;
   vector[nMT] log_sig_fn;
   //vector[nMT-1] z_e [NF];
   //real mu_rep_logit_fn[NF, nMT, nrep]; // Inferred fraction new of obs reads on native scale.
-  real z_fn[NF, nMT, nrep];
+  array[NF, nMT, nrep] real z_fn;
   vector<lower=0>[nMT] a;
   vector[nMT] b;
   vector<lower=0>[nMT] sd_rep;
-  vector[nMT] z_rep [NF];
+  array[NF] vector[nMT] z_rep;
   //vector<lower=0>[nMT] sd_r_mu[NF];
 }
 
 transformed parameters {
-  real mu_rep_logit_fn[NF, nMT, nrep]; // Inferred fraction new of obs reads on native scale.
+  array[NF, nMT, nrep] real mu_rep_logit_fn; // Inferred fraction new of obs reads on native scale.
   //vector[nMT-1] eff[NF]; //  Parameter for fraction new of observed reads
   vector<lower=0>[nMT] sig_fn = exp(log_sig_fn);
-  vector<lower=0>[nMT] sd_r_mu[NF];
+  array[NF] vector<lower=0>[nMT] sd_r_mu;
   //vector[nMT] sd_mean[NF];
 
     // Left here if needed for non-centered parameterization:
@@ -93,9 +93,9 @@ model {
 
  generated quantities {
 
-   vector[nMT] kd[NF]; // decay rate
-   vector[nMT-1] L2FC_kd[NF]; // change in decay rate
-   vector[nMT] log_kd[NF]; // log(kdeg)
+   array[NF] vector[nMT] kd; // decay rate
+   array[NF] vector[nMT-1] L2FC_kd; // change in decay rate
+   array[NF] vector[nMT] log_kd; // log(kdeg)
 
  for (i in 1:NF) {
    for (j in 1:nMT) {

--- a/inst/stan/Hybrid_NSS.stan
+++ b/inst/stan/Hybrid_NSS.stan
@@ -2,37 +2,37 @@
 data {
   int NE; //num entries in data frame.
   int NF; //num features
-  int MT[NE]; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
+  array[NE] int MT; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
   int nMT; // number of different mutation types
-  int FE[NE]; //  feature  for each entry
-  int R[NE]; //Replicate ID
+  array[NE] int FE; //  feature  for each entry
+  array[NE] int R; //Replicate ID
   int nrep;
-  real tl[nMT];
-  real logit_fn_rep[NE]; //Replicate fn estimate
-  real fn_se[NE] ; //Standard error of replicate fn estimate
-  real Avg_Reads[NF, nMT]; // Average read counts in transcript i and sample j (avg. across replicates)
+  array[nMT] real tl;
+  array[NE] real logit_fn_rep; //Replicate fn estimate
+  array[NE] real fn_se ; //Standard error of replicate fn estimate
+  array[NF, nMT] real Avg_Reads; // Average read counts in transcript i and sample j (avg. across replicates)
   int<lower=0, upper=1> Chase;
 }
 
 parameters {
-  vector[nMT] alpha[NF];
+  array[NF] vector[nMT] alpha;
   vector[nMT] mu_fn;
   vector[nMT] log_sig_fn;
   //vector[nMT-1] z_e [NF];
   //real mu_rep_logit_fn[NF, nMT, nrep]; // Inferred fraction new of obs reads on native scale.
-  real z_fn[NF, nMT, nrep];
+  array[NF, nMT, nrep] real z_fn;
   vector<lower=0>[nMT] a;
   vector[nMT] b;
   vector<lower=0>[nMT] sd_rep;
-  vector[nMT] z_rep [NF];
+  array[NF] vector[nMT] z_rep;
   //vector<lower=0>[nMT] sd_r_mu[NF];
 }
 
 transformed parameters {
-  real mu_rep_logit_fn[NF, nMT, nrep]; // Inferred fraction new of obs reads on native scale.
+  array[NF, nMT, nrep] real mu_rep_logit_fn; // Inferred fraction new of obs reads on native scale.
   //vector[nMT-1] eff[NF]; //  Parameter for fraction new of observed reads
   vector<lower=0>[nMT] sig_fn = exp(log_sig_fn);
-  vector<lower=0>[nMT] sd_r_mu[NF];
+  array[NF] vector<lower=0>[nMT] sd_r_mu;
   //vector[nMT] sd_mean[NF];
 
     // Left here if needed for non-centered parameterization:
@@ -93,9 +93,9 @@ model {
 
  generated quantities {
 
-   vector[nMT] kd[NF]; // decay rate
-   vector[nMT-1] L2FC_kd[NF]; // change in decay rate
-   vector[nMT] log_kd[NF]; // log(kdeg)
+   array[NF] vector[nMT] kd; // decay rate
+   array[NF] vector[nMT-1] L2FC_kd; // change in decay rate
+   array[NF] vector[nMT] log_kd; // log(kdeg)
 
   for (i in 1:NF) {
     for (j in 1:nMT) {

--- a/inst/stan/MCMC2.stan
+++ b/inst/stan/MCMC2.stan
@@ -2,42 +2,42 @@
 data {
   int NE; //num entries in data frame.
   int NF; //num features
-  int TP[NE]; // type for each entry (+s4U = 1, -s4U = 0)
-  int MT[NE]; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
+  array[NE] int TP; // type for each entry (+s4U = 1, -s4U = 0)
+  array[NE] int MT; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
   int nMT; // number of different mutation types
-  int FE[NE]; //  feature  for each entry
-  int num_mut[NE]; //  mutations in each entry
-  int num_obs[NE]; // number of times its observed
-  int R[NE]; //Replicate ID
-  real U_cont[NE]; // Feature specific log-fold difference in U content
+  array[NE] int FE; //  feature  for each entry
+  array[NE] int num_mut; //  mutations in each entry
+  array[NE] int num_obs; // number of times its observed
+  array[NE] int R; //Replicate ID
+  array[NE] real U_cont; // Feature specific log-fold difference in U content
   int nrep;  // Number of replicates
-  real tl[nMT];   // Label time
-  real Avg_Reads[NF, nMT]; // Average read counts in transcript i and sample j (avg. across replicates)
+  array[nMT] real tl;   // Label time
+  array[NF, nMT] real Avg_Reads; // Average read counts in transcript i and sample j (avg. across replicates)
   int<lower = 0, upper = 1> Chase;
   real nU;
 }
 
 parameters {
-  vector<lower=0>[nrep] TL_lambda_eff[nMT];   // s4U induced increase in mutation rate
-  vector[nrep] log_lambda_o[nMT];  // Background mutation rate
-  vector[nMT] alpha[NF];
-  real mu_fn[nMT];        // Global mean fn
-  real<lower=0> sig_fn[nMT];
-  real z_fn[NF, nMT, nrep];
+  array[nMT] vector<lower=0>[nrep] TL_lambda_eff;   // s4U induced increase in mutation rate
+  array[nMT] vector[nrep] log_lambda_o;  // Background mutation rate
+  array[NF] vector[nMT] alpha;
+  array[nMT] real mu_fn;        // Global mean fn
+  array[nMT] real<lower=0> sig_fn;
+  array[NF, nMT, nrep] real z_fn;
   //vector[nMT-1] z_e[NF];
   vector<lower=0>[nMT] a;
   vector[nMT] b;
-  vector[nMT] z_sd_r [NF];
+  array[NF] vector[nMT] z_sd_r ;
   vector<lower=0>[nMT] sig_rep;
   //vector<lower=0>[nMT] sd_r_mu [NF];
 }
 
 transformed parameters {
-  real<lower=0,upper=1> frac_new[NF, nMT, nrep];   // Fraction new (fn) of obs reads on native scale.
-  real mu_rep_logit_fn[NF, nMT, nrep]; // Fn on logit scale
-  vector[nrep] log_lambda_n[nMT]; // Mutation rate of s4U labelled reads
-  vector<lower=0>[nMT] sd_r_mu[NF];
-  vector[nMT] sd_rep[NF];
+  array[NF, nMT, nrep] real<lower=0,upper=1> frac_new;   // Fraction new (fn) of obs reads on native scale.
+  array[NF, nMT, nrep] real mu_rep_logit_fn; // Fn on logit scale
+  array[nMT] vector[nrep] log_lambda_n; // Mutation rate of s4U labelled reads
+  array[NF] vector<lower=0>[nMT] sd_r_mu;
+  array[NF] vector[nMT] sd_rep;
 
       for(m in 1:nMT){
         for(r in 1:nrep){
@@ -106,9 +106,9 @@ model {
 
 generated quantities {
 
-  vector[nMT] kd[NF]; // decay rate
-  vector[nMT-1] L2FC_kd[NF]; // change in decay rate
-  vector[nMT] log_kd[NF]; //log(kdeg)
+  array[NF] vector[nMT] kd; // decay rate
+  array[NF] vector[nMT-1] L2FC_kd; // change in decay rate
+  array[NF] vector[nMT] log_kd; //log(kdeg)
 
   for (i in 1:NF) {
     for (j in 1:nMT) {

--- a/inst/stan/MCMC_NSS.stan
+++ b/inst/stan/MCMC_NSS.stan
@@ -2,42 +2,42 @@
 data {
   int NE; //num entries in data frame.
   int NF; //num features
-  int TP[NE]; // type for each entry (+s4U = 1, -s4U = 0)
-  int MT[NE]; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
+  array[NE] int TP; // type for each entry (+s4U = 1, -s4U = 0)
+  array[NE] int MT; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
   int nMT; // number of different mutation types
-  int FE[NE]; //  feature  for each entry
-  int num_mut[NE]; //  mutations in each entry
-  int num_obs[NE]; // number of times its observed
-  int R[NE]; //Replicate ID
-  real U_cont[NE]; // Feature specific log-fold difference in U content
+  array[NE] int FE; //  feature  for each entry
+  array[NE] int num_mut; //  mutations in each entry
+  array[NE] int num_obs; // number of times its observed
+  array[NE] int R; //Replicate ID
+  array[NE] real U_cont; // Feature specific log-fold difference in U content
   int nrep;  // Number of replicates
-  real tl[nMT];   // Label time
-  real Avg_Reads[NF, nMT]; // Average read counts in transcript i and sample j (avg. across replicates)
+  array[nMT] real tl;   // Label time
+  array[NF, nMT] real Avg_Reads; // Average read counts in transcript i and sample j (avg. across replicates)
   int<lower=0, upper=1> Chase;
   real nU;
 }
 
 parameters {
-  vector<lower=0>[nrep] TL_lambda_eff[nMT];   // s4U induced increase in mutation rate
-  vector[nrep] log_lambda_o[nMT];  // Background mutation rate
-  vector[nMT] alpha[NF];
-  real mu_fn[nMT];        // Global mean fn
-  real<lower=0> sig_fn[nMT];
-  real z_fn[NF, nMT, nrep];
+  array[nMT] vector<lower=0>[nrep] TL_lambda_eff;   // s4U induced increase in mutation rate
+  array[nMT] vector[nrep] log_lambda_o;  // Background mutation rate
+  array[NF] vector[nMT] alpha;
+  array[nMT] real mu_fn;        // Global mean fn
+  array[nMT] real<lower=0> sig_fn;
+  array[NF, nMT, nrep] real z_fn;
   //vector[nMT-1] z_e[NF];
   vector<lower=0>[nMT] a;
   vector[nMT] b;
-  vector[nMT] z_sd_r [NF];
+  array[NF] vector[nMT] z_sd_r;
   vector<lower=0>[nMT] sig_rep;
   //vector<lower=0>[nMT] sd_r_mu [NF];
 }
 
 transformed parameters {
-  real<lower=0,upper=1> frac_new[NF, nMT, nrep];   // Fraction new (fn) of obs reads on native scale.
-  real mu_rep_logit_fn[NF, nMT, nrep]; // Fn on logit scale
-  vector[nrep] log_lambda_n[nMT]; // Mutation rate of s4U labelled reads
-  vector<lower=0>[nMT] sd_r_mu[NF];
-  vector[nMT] sd_rep[NF];
+  array[NF, nMT, nrep] real<lower=0,upper=1> frac_new;   // Fraction new (fn) of obs reads on native scale.
+  array[NF, nMT, nrep] real mu_rep_logit_fn; // Fn on logit scale
+  array[nMT] vector[nrep] log_lambda_n; // Mutation rate of s4U labelled reads
+  array[NF] vector<lower=0>[nMT] sd_r_mu;
+  array[NF] vector[nMT] sd_rep;
 
       for(m in 1:nMT){
         for(r in 1:nrep){
@@ -106,9 +106,9 @@ model {
 
 generated quantities {
 
-  vector[nMT] kd[NF]; // decay rate
-  vector[nMT-1] L2FC_kd[NF]; // change in decay rate
-  vector[nMT] log_kd[NF]; //log(kdeg)
+  array[NF] vector[nMT] kd; // decay rate
+  array[NF] vector[nMT-1] L2FC_kd; // change in decay rate
+  array[NF] vector[nMT] log_kd; //log(kdeg)
 
   for (i in 1:NF) {
     for (j in 1:nMT) {

--- a/inst/stan/Mutrate_est.stan
+++ b/inst/stan/Mutrate_est.stan
@@ -5,30 +5,30 @@
 data {
   int NE; //num entries in data frame.
   int NF; //num features
-  int TP[NE]; // type for each entry (+s4U = 1, -s4U = 0)
-  int MT[NE]; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
+  array[NE] int TP; // type for each entry (+s4U = 1, -s4U = 0)
+  array[NE] int MT; // mutant type for each entry (WT = 1, treatment A = 2, treatment B = 3, treatment C = 4)
   int nMT; // number of different mutation types
-  int FE[NE]; //  feature  for each entry
-  int num_mut[NE]; //  mutations in each entry
-  int num_obs[NE]; // number of times its observed
-  int R[NE]; //Replicate ID
-  real U_cont[NE]; // Feature specific log-fold difference in U content
+  array[NE] int FE; //  feature  for each entry
+  array[NE] int num_mut; //  mutations in each entry
+  array[NE] int num_obs; // number of times its observed
+  array[NE] int R; //Replicate ID
+  array[NE] real U_cont; // Feature specific log-fold difference in U content
   int nrep;
-  real tl[nMT];
+  array[nMT] real tl;
   real nU;
 }
 
 // Parameter block tells model all the things it will estimate
 parameters {
-  vector[nrep] log_lambda_o[nMT]; // Background mutation rate
-  vector<lower=0>[nrep] TL_lambda_eff[nMT]; // Increase to mutation rate due to s4U
-  real mu_rep_logit_fn[NF, nMT, nrep]; // Inferred fraction new of obs reads on native scale.
+  array[nMT] vector[nrep] log_lambda_o; // Background mutation rate
+  array[nMT] vector<lower=0>[nrep] TL_lambda_eff; // Increase to mutation rate due to s4U
+  array[NF, nMT, nrep] real mu_rep_logit_fn; // Inferred fraction new of obs reads on native scale.
 }
 
 // Transformed parameters are parameters that are defined in terms of data or other parameters
 transformed parameters {
-  real frac_new[NF, nMT, nrep] = inv_logit(mu_rep_logit_fn); // fraction new
-  vector[nrep] log_lambda_n[nMT]; // Inferred s4U-induced muatation rate per read
+  array[NF, nMT, nrep] real frac_new = inv_logit(mu_rep_logit_fn); // fraction new
+  array[nMT] vector[nrep] log_lambda_n; // Inferred s4U-induced muatation rate per read
 
   for(j in 1:nMT){
     for(k in 1:nrep){
@@ -72,8 +72,8 @@ model {
 // Things you can estimate once you have finished estimating parameters and transformed parameters
 generated quantities {
 
-  vector[nMT] kd[NF]; // decay rate
-  vector[nMT-1] L2FC_kd[NF]; // change in decay rate
+  array[NF] vector[nMT] kd; // decay rate
+  array[NF] vector[nMT-1] L2FC_kd; // change in decay rate
 
   for (i in 1:NF) {
     for (j in 1:nMT) {


### PR DESCRIPTION


Now that rstan 2.26 is available on CRAN we need to update your package's Stan models to use the new array syntax, otherwise it will fail to install with an upcoming version of RStan. If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
